### PR TITLE
error on latest versions of request

### DIFF
--- a/ddoc.js
+++ b/ddoc.js
@@ -49,11 +49,13 @@ var TEMPLATE =
 
 function validate_doc_update(newDoc, oldDoc, userCtx, secObj) {
   var ddoc = this;
-  var NAME = "XXX_name_XXX";
 
+  var NAME = "XXX_name_XXX";
   var my_msg_id = XXX_my_msg_id_XXX;
 
-  if(! /^CQS\//.test(newDoc._id)) // A simple test, hopefully future-proof
+  // Only allow CQS documents in this database. Hopefully this is future-proof.
+  var is_cqs = !! /^CQS\//.exec(newDoc._id);
+  if(! is_cqs)
     throw({forbidden: "This database is for CQS only"});
 
   var msg_id = my_msg_id(newDoc); // Message ID is the part within the queue namespace.
@@ -135,7 +137,7 @@ function visible_at(doc) {
     // which means MVCC stuff and anything else necessary.
     val = {"_id":doc._id, "_rev":doc._rev};
     for(a in doc)
-      if(/^[A-Z]/.test(a))
+      if(!! /^[A-Z]/.exec(a))
         val[a] = doc[a];
 
     emit(key, val);
@@ -232,7 +234,7 @@ DDoc.prototype.add_browser = function(callback) {
       if(er) return callback(er);
       self.log.debug('Files: ' + lib.JS(files));
 
-      files = files.filter(function(file) { return /\.js$/.test(file) || /\.html$/.test(file) });
+      files = files.filter(function(file) { return !! ( /\.js$/.exec(file) || /\.html$/.exec(file) ) });
 
       get_file();
       function get_file() {
@@ -293,7 +295,8 @@ DDoc.prototype.add_browser = function(callback) {
             return callback(new Error('Unknown directory: ' + att_dir));
 
           var att = att_dir + filename;
-          var type = /\.html$/.test(filename) ? 'text/html; charset=utf-8' : 'application/javascript';
+          var is_html = !! /\.html$/.exec(filename);
+          var type = is_html ? 'text/html; charset=utf-8' : 'application/javascript';
           self._attachments[att] = { 'content_type':type, 'data':content.toString('base64') };
 
           get_file();

--- a/lib.js
+++ b/lib.js
@@ -29,7 +29,7 @@ exports.JDUP = function(obj) { return JSON.parse(JSON.stringify(obj)) };
 exports.copy = function(src, dst, pred) {
   pred = pred || function() { return true };
   if(pred === 'uppercase')
-    pred = function(key) { return /^[A-Z]/.test(key) };
+    pred = function(key) { return !! /^[A-Z]/.exec(key) };
 
   Object.keys(src).forEach(function(key) {
     var val = src[key];

--- a/message.js
+++ b/message.js
@@ -131,7 +131,7 @@ Message.prototype.update = function update_message(callback) {
     else {
       // This message was deleted;
       for (key in self)
-        if(/^[A-Z]/.test(key))
+        if(!! /^[A-Z]/.exec(key))
           delete self[key];
       self.deleted = true;
     }
@@ -150,7 +150,7 @@ Message.prototype.receive = function receive_message(callback) {
 
   assert.ok(self.mvcc);
   assert.ok(self.mvcc._id);
-  assert.ok(new RegExp('/' + self.MessageId + '$').test(self.mvcc._id), lib.JS({_id:self.mvcc._id, ID:self.MessageId}));
+  assert.ok(new RegExp('/' + self.MessageId + '$').exec(self.mvcc._id), lib.JS({_id:self.mvcc._id, ID:self.MessageId}));
   assert.ok('ApproximateReceiveCount'          in self, util.inspect(self));
   assert.ok('ApproximateFirstReceiveTimestamp' in self);
 
@@ -283,7 +283,7 @@ Message.prototype.del = function message_del(callback) {
       self.log.info('Unknown response to delete' + lib.JS(result));
 
     Object.keys(self).forEach(function (key) {
-      if(/^[A-Z]/.test(key))
+      if(!! /^[A-Z]/.exec(key))
         delete self[key];
     })
 

--- a/test/run.js
+++ b/test/run.js
@@ -59,7 +59,7 @@ function run() {
   if(!test)
     return complete();
 
-  var starts_with_xx = /^xx/.test(test.name);
+  var starts_with_xx = !! /^xx/.exec(test.name);
   if(test.name !== 'setup') {
     if( XX_MEANS_EXCLUDE ? starts_with_xx : !starts_with_xx )
       return count.inc('skip');


### PR DESCRIPTION
On latest versions of request, when you get a JSON response, request already passes you a parsed object as the body.
Now, only if the given body is a string we try to parse it.
